### PR TITLE
Update to fix issues with missing http methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ deno which is the part of the reason why it's faster than node and deno.
 
 Bun is written in a low-level manual memory management programming language called [ZIG](https://ziglang.org).
 
-Bun supports ~90% of the native nodejs APIs including `fs`, `path`etc and also distribute it's packages using [npm](https://npmjs.com) hence both `yarn` and `npm` are supported in bun.
+Bun supports ~90% of the native nodejs APIs including `fs`, `path` etc. and also distribute it's packages using [npm](https://npmjs.com) hence both `yarn` and `npm` are supported in bun.
 
 Colstonjs is a fast, minimal and higly configurable typescript based api `framework` highly inspired by [_Expressjs_](https://expressjs.com) and [_fastify_](https://www.fastify.io) for building high performance APIs, colstonjs is completely built on bunjs.
 
@@ -98,16 +98,16 @@ app.get("/", function(ctx) {
 To allow the application to accept requests, we have to call the `start()` method with an optional
 port and/or callback function.
 
-This will start an `http` sever on the listening on all interfaces (`0.0.0.0`) listening on the specified port.
+This will start an `http` sever that is listening on all interfaces (`0.0.0.0`) on the specified port.
 
 ```typescript
 // server.ts
 ...
-server.start(port?, cb?);
+server.start(port?: number, cb?: Function);
 ```
 
 ### _NOTE_
-* _`port` number can be passed into the `app` through the server options or the as the first argument of the `start()` mthod. If the the port number is passed as part of the server options and also in the `start()` mthod, then port number passed into to the `start()` takes priority. If no neither is provided, then the app will default to port `3000`_
+* _`port` number can be passed into the `app` through the server options or the as the first argument of the `start()` method. If the the port number is passed as part of the server options and also in the `start()` method, then port number passed into to the `start()` takes priority. If neither is provided, then the app will default to port `3000`_
 
 * _`callback` method is immediately invoked once the connection is successfully established and the application is ready to accept requests._
 
@@ -210,7 +210,7 @@ app.start(8000);
 ```
 
 #### Running the demo `note-app`
-Follow the steps below to run the `demo note-taking api application` in the `examples`directory.
+Follow the steps below to run the `demo note-taking api application` in the `examples` directory.
 - Clone this repository
 - Change directory into the note-app folder by running `cd examples/note-app`
 - Start the http server to listen on port `8000` by running `bun app.js`

--- a/src/colston.ts
+++ b/src/colston.ts
@@ -42,7 +42,6 @@ export default class Colston implements IColston {
   }
 
   /**
-   * 
    * @param key 
    * @param value 
    */
@@ -139,8 +138,6 @@ export default class Colston implements IColston {
    * @returns {Response} bun response object
    */
   async fetch(request: Request): Promise<Response> {
-    // https://github.com/oven-sh/bun/issues/677
-    if (!request.method) request.verb = 'DELETE';
     const context = new Context(request);
     /**
      * invoke all app level middlewares
@@ -163,9 +160,9 @@ export default class Colston implements IColston {
 
       if (
         new RegExp(parsedRoute).test(request.url) &&
-        this.routeTable[i][route[0]]?.[request.method.toLowerCase() || request.verb.toLowerCase()]
+        this.routeTable[i][route[0]]?.[request.method.toLowerCase()]
       ) {
-        const middleware = this.routeTable[i][route[0]][request.method.toLowerCase() || request.verb.toLowerCase()];
+        const middleware = this.routeTable[i][route[0]][request.method.toLowerCase()];
         const m = request.url.match(new RegExp(parsedRoute));
 
         const _middleware = middleware.slice();

--- a/src/routeRegister.ts
+++ b/src/routeRegister.ts
@@ -8,9 +8,9 @@ export default function register(path: string, method: MethodType, callback: Arr
 function validate(path: string, method: MethodType, callback: Array<Middleware>): { [path: string]: Array<Middleware> } {
   if (methods.indexOf(method) === -1) throw new Error("Invalid HTTP method, Accepted methods are: " + methods.join(" "));
   if (path.charAt(0) !== "/") throw new Error("Invalid path, path must start with '/'");
-  
+
   for (const i in callback)
-  if (typeof callback[i] !== "function") throw new Error("Invalid handler function, handler must be a function");
-  
+    if (typeof callback[i] !== "function") throw new Error("Invalid handler function, handler must be a function");
+
   return { [method.toLowerCase()]: callback };
 }


### PR DESCRIPTION
### Summary
There was [issue](https://github.com/oven-sh/bun/issues/677) with bun where some http methods are missing and are not as part of the request methods. This was fixed [here](https://github.com/oven-sh/bun/commit/8e5b1c44bc165eff9546945d898f997bfbde9db4), hence the need to update `colstonjs` to deal with this change.

###
Tasks to be completed
- [x] Remove the check that handles missing http methods.
- [x] Ensure colstonjs still works as expected

### Releated issues
See [issue](https://github.com/oven-sh/bun/issues/677) in bunjs repository